### PR TITLE
Made jwt secret configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cp magento1-module/app/* <MAGENTO_FOLDER>/app/
 
 Magento module uses JWT tokens authorization method based on standard Magento admin users account system. **Please create a dedicated admin account** for magento1-bridge purposes only with minimal access (ACL) to the catalog part.
 
-Then, please setup the JWT "secretToken" by modifying: [`magento1-module/app/etc/modules/Divante_VueStorefrontBridge.xml`](https://github.com/DivanteLtd/magento1-vsbridge/blob/master/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml)
+Then, please configure the JWT Secret in Magento configuration: System > Configuration > Services > VueStorefront Bridge.
 
 https://github.com/DivanteLtd/magento1-vsbridge/blob/3f92a6d842e6afb4c7e34e789229848710127b8b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml#L5
 

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AbstractController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AbstractController.php
@@ -17,6 +17,8 @@ function _filterDTO($dtoToFilter, array $blackList = null) {
 }
 class Divante_VueStorefrontBridge_AbstractController extends Mage_Core_Controller_Front_Action
 {
+    const XML_CONFIG_JWT_SECRET = 'vsbridge/general/jwt_secret';
+
     public function init()
     {
         $this->getResponse()->setHeader('Content-Type', 'application/json');        
@@ -24,7 +26,7 @@ class Divante_VueStorefrontBridge_AbstractController extends Mage_Core_Controlle
 
     protected function _authorize($request) {
         $apikey = $request->getParam('apikey');
-        $secretKey = trim(Mage::getConfig()->getNode('default/auth/secret'));
+        $secretKey = trim(Mage::getStoreConfig(self::XML_CONFIG_JWT_SECRET));
 
         try {
             $tokenData = JWT::decode($apikey, $secretKey, 'HS256');

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AuthController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AuthController.php
@@ -3,7 +3,7 @@ require_once('AbstractController.php');
 require_once(__DIR__.'/../helpers/JWT.php');
 class Divante_VueStorefrontBridge_AuthController extends Divante_VueStorefrontBridge_AbstractController
 {
-    const XML_CONFIG_JWT_SECRET = 'vsbridge/general/jwt_token';
+    const XML_CONFIG_JWT_SECRET = 'vsbridge/general/jwt_secret';
 
     public function adminAction()
     {

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AuthController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AuthController.php
@@ -3,6 +3,8 @@ require_once('AbstractController.php');
 require_once(__DIR__.'/../helpers/JWT.php');
 class Divante_VueStorefrontBridge_AuthController extends Divante_VueStorefrontBridge_AbstractController
 {
+    const XML_CONFIG_JWT_SECRET = 'vsbridge/general/jwt_token';
+
     public function adminAction()
     {
         if($this->getRequest()->getMethod() !== 'POST'){
@@ -18,7 +20,7 @@ class Divante_VueStorefrontBridge_AuthController extends Divante_VueStorefrontBr
                     return $this->_result(500, 'No username or password given!');
                 } else {
                     $session = Mage::getSingleton('admin/session');
-                    $secretKey = trim(Mage::getConfig()->getNode('default/auth/secret'));
+                    $secretKey = trim(Mage::getStoreConfig(self::XML_CONFIG_JWT_SECRET));
 
                     $user = $session->login($request->username, $request->password);
                     if ($user->getId()) {

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AuthController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AuthController.php
@@ -3,8 +3,6 @@ require_once('AbstractController.php');
 require_once(__DIR__.'/../helpers/JWT.php');
 class Divante_VueStorefrontBridge_AuthController extends Divante_VueStorefrontBridge_AbstractController
 {
-    const XML_CONFIG_JWT_SECRET = 'vsbridge/general/jwt_secret';
-
     public function adminAction()
     {
         if($this->getRequest()->getMethod() !== 'POST'){

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/adminhtml.xml
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/adminhtml.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<config>
+    <acl>
+        <resources>
+            <admin>
+                <children>
+                    <system>
+                        <children>
+                            <config>
+                                <children>
+                                    <vsbridge translate="title">
+                                        <title>VueStorefront Bridge</title>
+                                        <sort_order>40</sort_order>
+                                    </vsbridge>
+                                </children>
+                            </config>
+                        </children>
+                    </system>
+                </children>
+            </admin>
+        </resources>
+    </acl>
+</config>

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
 <config>
-    <default>
-        <auth>
-            <secret>
-                Geiw0qua
-            </secret>
-        </auth>
-    </default>
     <modules>
         <Divante_VueStorefrontBridge>
             <version>1.0.3</version>
         </Divante_VueStorefrontBridge>
     </modules>
-  <frontend>
+    <global>
+    </global>
+    <frontend>
         <routers>
             <vsbridge>
                 <use>standard</use>
@@ -22,7 +17,12 @@
                 </args>
             </vsbridge>
         </routers>
-    </frontend>    
-    <global>
-    </global>
+    </frontend>
+    <default>
+        <vsbridge>
+            <general>
+                <jwt_token>Geiw0qua</jwt_token>
+            </general>
+        </vsbridge>
+    </default>
 </config>

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
@@ -21,7 +21,7 @@
     <default>
         <vsbridge>
             <general>
-                <jwt_token>Geiw0qua</jwt_token>
+                <jwt_secret>Geiw0qua</jwt_secret>
             </general>
         </vsbridge>
     </default>

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/system.xml
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/system.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<config>
+    <sections>
+        <vsbridge translate="label" module="oauth">
+            <label>VueStorefront Bridge</label>
+            <tab>service</tab>
+            <frontend_type>text</frontend_type>
+            <sort_order>400</sort_order>
+            <show_in_default>1</show_in_default>
+            <show_in_website>1</show_in_website>
+            <show_in_store>1</show_in_store>
+            <groups>
+                <general translate="label">
+                    <label>General</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>300</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <jwt_secret translate="label">
+                            <label>JWT Secret</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>JSON Web Token secret for VueStorefront Bridge</comment>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </jwt_secret>
+                    </fields>
+                </general>
+            </groups>
+        </vsbridge>
+    </sections>
+</config>


### PR DESCRIPTION
The JWT secret had to be configured in app/code/local/Divante/VueStorefrontBridge/etc/config.xml. To make it easier to setup and also to configure the secret on store view level I added a system.xml and adminhtml.xml to make this all configurable in the Magento admin and follow best practices.