### PR TITLE
Add RewriteController to allow easy handling of historic rewrites

### DIFF
--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/RewriteController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/RewriteController.php
@@ -1,0 +1,27 @@
+<?php
+require_once Mage::getModuleDir('controllers', 'Divante_VueStorefrontBridge') . DS . 'AbstractController.php';
+class Divante_VueStorefrontBridge_RewriteController extends Divante_VueStorefrontBridge_AbstractController {
+
+    public function targetAction()
+    {
+
+        if (!$this->_checkHttpMethod('GET')) {
+            return $this->_result(500, 'Only GET method allowed');
+        }
+        $requestPath = $this->getRequest()->getParam('request_path');
+        if ($requestPath) {
+
+            $reader = Mage::getSingleton('core/resource')->getConnection('core_read');
+            $select = $reader->select()
+                             ->from('core_url_rewrite', ['target_path'])->where('request_path = ?', $requestPath);
+            $result = $reader->fetchOne($select);
+
+            if ($result) {
+                return $this->_result(200, $result);
+            }
+        }
+
+        return $this->_result(500, 'Not possible to retrieve target location');
+    }
+
+}


### PR DESCRIPTION
Added a new controller to be able to access the old rewrites vsf-api knows nothing about. It simply makes a DB call to core_url_rewrite, filtered by request_path and returns only the new final target.
## Usage
Simply called by /vsbridge/rewrite/target?request_path=old_url this returns {"code":200,"result":"target_path"}

As we agreed with Łukasz Romanowicz on slack we should bring this functionality to the main magento1 trunk.