### PR TITLE
Add functionality to have bundle options in cart items returned by api

### DIFF
--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Api/Cart.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Api/Cart.php
@@ -57,6 +57,8 @@ class Divante_VueStorefrontBridge_Model_Api_Cart
 
             $item['product_option']['extension_attributes'] = [
                 'configurable_item_options' => $this->cartItem->getConfigurableOptions($cartItem),
+                'bundle_options' => $this->cartItem->getBundleOptions($cartItem),
+
             ];
 
             return $item;

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Api/Cart/Item.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Api/Cart/Item.php
@@ -39,4 +39,16 @@ class Divante_VueStorefrontBridge_Model_Api_Cart_Item
 
         return $configurableOptions;
     }
+
+    public function getBundleOptions(Mage_Catalog_Model_Product_Configuration_Item_Interface $item)
+    {
+        $product = Mage::getModel('catalog/product')->load($item->getProduct()->getId());
+        if ($product->getTypeId() === 'bundle') {
+            $options = $item->getProduct()->getTypeInstance(true)
+                            ->getOrderOptions($item->getProduct())['bundle_options'];
+        }
+
+        return $options;
+
+    }
 }


### PR DESCRIPTION
The bridge only returned configurable options and no bundle options. As
the product is compared by this we need something to differentiate
bundle products from each other. Content of the array is inspired by the
M2 version of the bridge extension.