### PR TITLE
Add mapper to fit response with needed schema and add a way to extend it

### DIFF
--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
@@ -62,7 +62,22 @@ abstract class Divante_VueStorefrontBridge_Helper_Mapper_Abstract extends Mage_C
             }
         }
 
+        $this->callMapperExtensions($dto);
+
         return $dto;
+    }
+
+    /**
+     * Allow to extend the mappers using config.xml
+     *
+     * @param array $dto
+     * @return array
+     */
+    protected function callMapperExtensions(&$dto)
+    {
+        /** @var Divante_VueStorefrontBridge_Model_Config_Mapper $model */
+        $model = Mage::getModel('vsbridge/config_mapper');
+        return $model->applyExtendedMapping(self::MAPPER_IDENTIFIER, $dto);
     }
 
     /**

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
@@ -37,34 +37,34 @@ abstract class Divante_VueStorefrontBridge_Helper_Mapper_Abstract extends Mage_C
             }
 
             if (in_array($key, $this->getAttributesToCastInt())) {
-                $dto[$key] = $dto[$key] != null ? intval($dto[$key]) : null;
+                $dto[$key] = $dto[$key] !== null ? intval($dto[$key]) : null;
                 $isCustom = true;
             }
 
             if (in_array($key, $this->getAttributesToCastBool())) {
-                $dto[$key] = $dto[$key] != null ? boolval($dto[$key]) : null;
+                $dto[$key] = $dto[$key] !== null ? boolval($dto[$key]) : null;
                 $isCustom = true;
             }
 
             if (in_array($key, $this->getAttributesToCastStr())) {
-                $dto[$key] = $dto[$key] != null ? strval($dto[$key]) : null;
+                $dto[$key] = $dto[$key] !== null ? strval($dto[$key]) : null;
                 $isCustom = true;
             }
 
             if (in_array($key, $this->getAttributesToCastFloat())) {
-                $dto[$key] = $dto[$key] != null ? floatval($dto[$key]) : null;
+                $dto[$key] = $dto[$key] !== null ? floatval($dto[$key]) : null;
                 $isCustom = true;
             }
 
             if (!$isCustom) {
                 // If beginning by "use", "has", ... , then must be a boolean (can be overriden using cast array)
                 if (preg_match('#^(use|has|is|enable|disable)_.*$#', $key)) {
-                    $dto[$key] = $dto[$key] != null ? boolval($value) : null;
+                    $dto[$key] = $dto[$key] !== null ? boolval($value) : null;
                 }
 
                 // If ending by "id", then must be an integer (can be overriden using cast array)
                 if (preg_match('#^.*_?id$#', $key)) {
-                    $dto[$key] = $dto[$key] != null ? intval($value) : null;
+                    $dto[$key] = $dto[$key] !== null ? intval($value) : null;
                 }
             }
         }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Divante VueStorefrontBridge AbstractMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+abstract class Divante_VueStorefrontBridge_Helper_Mapper_Abstract extends Mage_Core_Helper_Abstract
+{
+    /**
+     * Get and process Dto from entity
+     *
+     * @param array $initialDto
+     *
+     * @return array
+     */
+    final public function filterDto($initialDto)
+    {
+        $dto = $this->customDtoFiltering($initialDto);
+
+        foreach ($dto as $key => $value) {
+            $isCustom = false;
+
+            if (in_array($key, $this->getBlacklist())) {
+                unset($dto[$key]);
+                continue;
+            }
+
+            if (in_array($key, $this->getAttributesToCastInt())) {
+                $dto[$key] = $dto[$key] != null ? intval($dto[$key]) : null;
+                $isCustom = true;
+            }
+
+            if (in_array($key, $this->getAttributesToCastBool())) {
+                $dto[$key] = $dto[$key] != null ? boolval($dto[$key]) : null;
+                $isCustom = true;
+            }
+
+            if (in_array($key, $this->getAttributesToCastStr())) {
+                $dto[$key] = $dto[$key] != null ? strval($dto[$key]) : null;
+                $isCustom = true;
+            }
+
+            if (in_array($key, $this->getAttributesToCastFloat())) {
+                $dto[$key] = $dto[$key] != null ? floatval($dto[$key]) : null;
+                $isCustom = true;
+            }
+
+            if (!$isCustom) {
+                // If beginning by "use", "has", ... , then must be a boolean (can be overriden using cast array)
+                if (preg_match('#^(use|has|is|enable|disable)_.*$#', $key)) {
+                    $dto[$key] = $dto[$key] != null ? boolval($value) : null;
+                }
+
+                // If ending by "id", then must be an integer (can be overriden using cast array)
+                if (preg_match('#^.*_?id$#', $key)) {
+                    $dto[$key] = $dto[$key] != null ? intval($value) : null;
+                }
+            }
+        }
+
+        return $dto;
+    }
+
+    /**
+     * Apply custom dto filtering
+     *
+     * @param array $dto
+     *
+     * @return array
+     */
+    protected function customDtoFiltering($dto)
+    {
+        return $dto;
+    }
+
+    /**
+     * Get Dto attribute blacklist
+     *
+     * @return array
+     */
+    protected function getBlacklist()
+    {
+        return [];
+    }
+
+    /**
+     * Get attribute list to cast to integer
+     *
+     * @return array
+     */
+    protected function getAttributesToCastInt()
+    {
+        return [];
+    }
+
+    /**
+     * Get attribute list to cast to boolean
+     *
+     * @return array
+     */
+    protected function getAttributesToCastBool()
+    {
+        return [];
+    }
+
+    /**
+     * Get attribute list to cast to string
+     *
+     * @return array
+     */
+    protected function getAttributesToCastStr()
+    {
+        return [];
+    }
+
+    /**
+     * Get attribute list to cast to float
+     *
+     * @return array
+     */
+    protected function getAttributesToCastFloat()
+    {
+        return [];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Abstract.php
@@ -11,13 +11,20 @@
 abstract class Divante_VueStorefrontBridge_Helper_Mapper_Abstract extends Mage_Core_Helper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
+     */
+    protected $_mapperIdentifier = '';
+
+    /**
      * Get and process Dto from entity
      *
      * @param array $initialDto
+     * @param bool $callMapperExtensions
      *
      * @return array
      */
-    final public function filterDto($initialDto)
+    final public function filterDto($initialDto, $callMapperExtensions = true)
     {
         $dto = $this->customDtoFiltering($initialDto);
 
@@ -62,7 +69,9 @@ abstract class Divante_VueStorefrontBridge_Helper_Mapper_Abstract extends Mage_C
             }
         }
 
-        $this->callMapperExtensions($dto);
+        if ($callMapperExtensions) {
+            $this->callMapperExtensions($dto);
+        }
 
         return $dto;
     }
@@ -77,7 +86,7 @@ abstract class Divante_VueStorefrontBridge_Helper_Mapper_Abstract extends Mage_C
     {
         /** @var Divante_VueStorefrontBridge_Model_Config_Mapper $model */
         $model = Mage::getModel('vsbridge/config_mapper');
-        return $model->applyExtendedMapping(self::MAPPER_IDENTIFIER, $dto);
+        return $model->applyExtendedMapping($this->_mapperIdentifier, $dto);
     }
 
     /**

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Address.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Address.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Address extends Divante_VueStore
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'address';
+    protected $_mapperIdentifier = 'address';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Address.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Address.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge AddressMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Address extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function customDtoFiltering($dto)
+    {
+        if (!is_array($dto['street'])) {
+            $dto['street'] = explode("\n", $dto['street']);
+        }
+
+        return $dto;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastStr()
+    {
+        return [
+            'country_id'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastBool()
+    {
+        return [
+            'default_billing',
+            'default_shipping'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Address.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Address.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_Address extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'address';
+
+    /**
      * @inheritdoc
      */
     protected function customDtoFiltering($dto)

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Category.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Category.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Category extends Divante_VueStor
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'category';
+    protected $_mapperIdentifier = 'category';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Category.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Category.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge CategoryMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Category extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getBlacklist()
+    {
+        return [
+            'entity_id',
+            'path'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastInt()
+    {
+        return [
+            'position',
+            'level',
+            'children_count'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastBool()
+    {
+        return [
+            'include_in_menu'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Category.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Category.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_Category extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'category';
+
+    /**
      * @inheritdoc
      */
     protected function getBlacklist()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Customer.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Customer.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge CustomerMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Customer extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getBlacklist()
+    {
+        return [
+            'password',
+            'password_hash',
+            'password_confirmation',
+            'password_created_at',
+            'confirmation',
+            'entity_type_id'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastInt()
+    {
+        return [
+            'default_billing',
+            'default_shipping'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Customer.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Customer.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_Customer extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'customer';
+
+    /**
      * @inheritdoc
      */
     protected function getBlacklist()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Customer.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Customer.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Customer extends Divante_VueStor
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'customer';
+    protected $_mapperIdentifier = 'customer';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Order.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Order.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge OrderMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Order extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastInt()
+    {
+        return [
+            'total_item_count'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastBool()
+    {
+        return [
+            'customer_is_guest',
+            'email_sent',
+            'paypal_ipn_customer_notified'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastFloat()
+    {
+        return [
+            'base_discount_amount',
+            'base_discount_canceled',
+            'base_discount_invoiced',
+            'base_discount_refunded',
+            'base_grand_total',
+            'base_shipping_amount',
+            'base_shipping_canceled',
+            'base_shipping_invoiced',
+            'base_shipping_refunded',
+            'base_shipping_tax_amount',
+            'base_shipping_tax_refunded',
+            'base_subtotal',
+            'base_subtotal_canceled',
+            'base_subtotal_invoiced',
+            'base_subtotal_refunded',
+            'base_tax_amount',
+            'base_tax_canceled',
+            'base_tax_invoiced',
+            'base_tax_refunded',
+            'base_to_global_rate',
+            'base_to_order_rate',
+            'base_total_canceled',
+            'base_total_invoiced',
+            'base_total_invoiced_cost',
+            'base_total_offline_refunded',
+            'base_total_online_refunded',
+            'base_total_paid',
+            'base_total_qty_ordered',
+            'base_total_refunded',
+            'discount_amount',
+            'discount_canceled',
+            'discount_invoiced',
+            'discount_refunded',
+            'grand_total',
+            'shipping_amount',
+            'shipping_canceled',
+            'shipping_invoiced',
+            'shipping_refunded',
+            'shipping_tax_amount',
+            'shipping_tax_refunded',
+            'store_to_base_rate',
+            'store_to_order_rate',
+            'subtotal',
+            'subtotal_canceled',
+            'subtotal_invoiced',
+            'subtotal_refunded',
+            'tax_amount',
+            'tax_canceled',
+            'tax_invoiced',
+            'tax_refunded',
+            'total_canceled',
+            'total_invoiced',
+            'total_offline_refunded',
+            'total_online_refunded',
+            'total_paid',
+            'total_qty_ordered',
+            'total_refunded',
+            // "can_ship_partially": null,
+            // "can_ship_partially_item": null,
+            'adjustment_negative',
+            'adjustment_positive',
+            'base_adjustment_negative',
+            'base_adjustment_positive',
+            'base_shipping_discount_amount',
+            'base_subtotal_incl_tax',
+            'base_total_due',
+            'payment_authorization_amount',
+            'shipping_discount_amount',
+            'subtotal_incl_tax',
+            'total_due',
+            'weight',
+            'hidden_tax_amount',
+            'base_hidden_tax_amount',
+            'shipping_hidden_tax_amount',
+            'base_shipping_hidden_tax_amnt',
+            'base_shipping_hidden_tax_amount',
+            'hidden_tax_invoiced',
+            'base_hidden_tax_invoiced',
+            'hidden_tax_refunded',
+            'base_hidden_tax_refunded',
+            'shipping_incl_tax',
+            'base_shipping_incl_tax',
+            'base_customer_balance_amount',
+            'customer_balance_amount',
+            'base_customer_balance_invoiced',
+            'customer_balance_invoiced',
+            'base_customer_balance_refunded',
+            'customer_balance_refunded',
+            'bs_customer_bal_total_refunded',
+            'customer_bal_total_refunded',
+            'base_gift_cards_amount',
+            'gift_cards_amount',
+            'base_gift_cards_invoiced',
+            'gift_cards_invoiced',
+            'base_gift_cards_refunded',
+            'gift_cards_refunded',
+            'gw_base_price',
+            'gw_price',
+            'gw_items_base_price',
+            'gw_items_price',
+            'gw_card_base_price',
+            'gw_card_price',
+            'gw_base_tax_amount',
+            'gw_tax_amount',
+            'gw_items_base_tax_amount',
+            'gw_items_tax_amount',
+            'gw_card_base_tax_amount',
+            'gw_card_tax_amount',
+            'gw_base_price_invoiced',
+            'gw_price_invoiced',
+            'gw_items_base_price_invoiced',
+            'gw_items_price_invoiced',
+            'gw_card_base_price_invoiced',
+            'gw_card_price_invoiced',
+            'gw_base_tax_amount_invoiced',
+            'gw_tax_amount_invoiced',
+            'gw_items_base_tax_invoiced',
+            'gw_items_tax_invoiced',
+            'gw_card_base_tax_invoiced',
+            'gw_card_tax_invoiced',
+            'gw_base_price_refunded',
+            'gw_price_refunded',
+            'gw_items_base_price_refunded',
+            'gw_items_price_refunded',
+            'gw_card_base_price_refunded',
+            'gw_card_price_refunded',
+            'gw_base_tax_amount_refunded',
+            'gw_tax_amount_refunded',
+            'gw_items_base_tax_refunded',
+            'gw_items_tax_refunded',
+            'gw_card_base_tax_refunded',
+            'gw_card_tax_refunded',
+            'reward_points_balance',
+            'base_reward_currency_amount',
+            'reward_currency_amount',
+            'base_rwrd_crrncy_amt_invoiced',
+            'rwrd_currency_amount_invoiced',
+            'base_rwrd_crrncy_amnt_refnded',
+            'rwrd_crrncy_amnt_refunded',
+            'reward_points_balance_refund',
+            'reward_points_balance_refunded'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Order.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Order.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_Order extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'order';
+
+    /**
      * @inheritdoc
      */
     protected function getAttributesToCastInt()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Order.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Order.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Order extends Divante_VueStorefr
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'order';
+    protected $_mapperIdentifier = 'order';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/OrderItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/OrderItem.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_OrderItem extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'order_item';
+
+    /**
      * @inheritdoc
      */
     protected function getAttributesToCastFloat()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/OrderItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/OrderItem.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge OrderItemMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_OrderItem extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastFloat()
+    {
+        return [
+            'weight',
+            'base_cost',
+            'price',
+            'base_price',
+            'original_price',
+            'base_original_price',
+            'tax_percent',
+            'tax_amount',
+            'base_tax_amount',
+            'tax_invoiced',
+            'base_tax_invoiced',
+            'discount_percent',
+            'discount_amount',
+            'base_discount_amount',
+            'discount_invoiced',
+            'base_discount_invoiced',
+            'amount_refunded',
+            'base_amount_refunded',
+            'row_total',
+            'base_row_total',
+            'row_invoiced',
+            'base_row_invoiced',
+            'row_weight',
+            'base_tax_before_discount',
+            'tax_before_discount',
+            'price_incl_tax',
+            'base_price_incl_tax',
+            'row_total_incl_tax',
+            'base_row_total_incl_tax',
+            'hidden_tax_amount',
+            'base_hidden_tax_amount',
+            'hidden_tax_invoiced',
+            'base_hidden_tax_invoiced',
+            'hidden_tax_refunded',
+            'base_hidden_tax_refunded',
+            'tax_canceled',
+            'hidden_tax_canceled',
+            'tax_refunded',
+            'base_tax_refunded',
+            'discount_refunded',
+            'base_discount_refunded',
+            'base_weee_tax_applied_amount',
+            'base_weee_tax_applied_row_amnt',
+            'base_weee_tax_applied_row_amount',
+            'weee_tax_applied_amount',
+            'weee_tax_applied_row_amount',
+            'weee_tax_applied',
+            'weee_tax_disposition',
+            'weee_tax_row_disposition',
+            'base_weee_tax_disposition',
+            'base_weee_tax_row_disposition',
+            'gw_base_price',
+            'gw_price',
+            'gw_base_tax_amount',
+            'gw_tax_amount',
+            'gw_base_price_invoiced',
+            'gw_price_invoiced',
+            'gw_base_tax_amount_invoiced',
+            'gw_tax_amount_invoiced',
+            'gw_base_price_refunded',
+            'gw_price_refunded',
+            'gw_base_tax_amount_refunded',
+            'gw_tax_amount_refunded',
+            'qty_returned'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/OrderItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/OrderItem.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_OrderItem extends Divante_VueSto
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'order_item';
+    protected $_mapperIdentifier = 'order_item';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Payment.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Payment.php
@@ -13,6 +13,7 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Payment extends Divante_VueStore
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'payment';
+    protected $_mapperIdentifier = 'payment';
 }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Payment.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Payment.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge PaymentMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Payment extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Payment.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Payment.php
@@ -11,4 +11,8 @@
  */
 class Divante_VueStorefrontBridge_Helper_Mapper_Payment extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
+    /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'payment';
 }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Product.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Product.php
@@ -13,6 +13,7 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Product extends Divante_VueStore
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'product';
+    protected $_mapperIdentifier = 'product';
 }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Product.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Product.php
@@ -11,4 +11,8 @@
  */
 class Divante_VueStorefrontBridge_Helper_Mapper_Product extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
+    /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'product';
 }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Product.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Product.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge ProductMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Product extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductAttribute.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductAttribute.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge ProductAttributeMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_ProductAttribute extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastInt()
+    {
+        return [
+            'default_value',
+            'position'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastBool()
+    {
+        return [
+            'used_in_product_listing',
+            'used_for_sort_by'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductAttribute.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductAttribute.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_ProductAttribute extends Divante
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'product_attribute';
+    protected $_mapperIdentifier = 'product_attribute';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductAttribute.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductAttribute.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_ProductAttribute extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'product_attribute';
+
+    /**
      * @inheritdoc
      */
     protected function getAttributesToCastInt()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductChild.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductChild.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge ProductChildMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_ProductChild extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getBlacklist()
+    {
+        return [
+            'entity_id',
+            'id',
+            'type_id',
+            'updated_at',
+            'created_at',
+            'stock_item',
+            'short_description',
+            'page_layout',
+            'news_from_date',
+            'news_to_date',
+            'meta_description',
+            'meta_keyword',
+            'meta_title',
+            'description',
+            'attribute_set_id',
+            'entity_type_id',
+            'has_options',
+            'required_options'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductChild.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductChild.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_ProductChild extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'product_child';
+
+    /**
      * @inheritdoc
      */
     protected function getBlacklist()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductChild.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/ProductChild.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_ProductChild extends Divante_Vue
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'product_child';
+    protected $_mapperIdentifier = 'product_child';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/QuoteItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/QuoteItem.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_QuoteItem extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'quote_item';
+
+    /**
      * @inheritdoc
      */
     protected function getAttributesToCastStr()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/QuoteItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/QuoteItem.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge QuoteItemMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_QuoteItem extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastStr()
+    {
+        return [
+            'quote_id'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/QuoteItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/QuoteItem.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_QuoteItem extends Divante_VueSto
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'quote_item';
+    protected $_mapperIdentifier = 'quote_item';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Stock.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Stock.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge StockMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Stock extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastBool()
+    {
+        return [
+            'stock_status_changed_auto',
+            'stock_status_changed_automatically'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Stock.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Stock.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_Stock extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'stock';
+
+    /**
      * @inheritdoc
      */
     protected function getAttributesToCastBool()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Stock.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Stock.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Stock extends Divante_VueStorefr
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'stock';
+    protected $_mapperIdentifier = 'stock';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Taxrule.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Taxrule.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge TaxruleMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_Taxrule extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getBlacklist()
+    {
+        return [
+            'tax_calculation_rule_id',
+            'tax_rates',
+            'product_tax_classes',
+            'customer_tax_classes'
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAttributesToCastInt()
+    {
+        return [
+            'position',
+            'priority'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Taxrule.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Taxrule.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_Taxrule extends Divante_VueStore
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'taxrule';
+    protected $_mapperIdentifier = 'taxrule';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Taxrule.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/Taxrule.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_Taxrule extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'taxrule';
+
+    /**
      * @inheritdoc
      */
     protected function getBlacklist()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/TaxruleRate.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/TaxruleRate.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge TaxruleRateMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_TaxruleRate extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getBlacklist()
+    {
+        return [
+            'tax_calculation_rate_id'
+        ];
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/TaxruleRate.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/TaxruleRate.php
@@ -13,8 +13,9 @@ class Divante_VueStorefrontBridge_Helper_Mapper_TaxruleRate extends Divante_VueS
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'taxrule_rate';
+    protected $_mapperIdentifier = 'taxrule_rate';
 
     /**
      * @inheritdoc

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/TaxruleRate.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/TaxruleRate.php
@@ -12,6 +12,11 @@
 class Divante_VueStorefrontBridge_Helper_Mapper_TaxruleRate extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
     /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'taxrule_rate';
+
+    /**
      * @inheritdoc
      */
     protected function getBlacklist()

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/WhishListItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/WhishListItem.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Divante VueStorefrontBridge WhishListItemMapper Class
+ *
+ * @category    Divante
+ * @package     VueStorefrontBridge
+ * @author      Mathias Arlaud <marlaud@sutunam.com>
+ * @copyright   Copyright (C) 2019
+ * @license     MIT License
+ */
+class Divante_VueStorefrontBridge_Helper_Mapper_WhishListItem extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
+{
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/WhishListItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/WhishListItem.php
@@ -13,6 +13,7 @@ class Divante_VueStorefrontBridge_Helper_Mapper_WhishListItem extends Divante_Vu
 {
     /**
      * Name to address custom mappers via config.xml
+     * @var string $_mapperIdentifier
      */
-    const MAPPER_IDENTIFIER = 'whishlist_item';
+    protected $_mapperIdentifier = 'whishlist_item';
 }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/WhishListItem.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Helper/Mapper/WhishListItem.php
@@ -11,4 +11,8 @@
  */
 class Divante_VueStorefrontBridge_Helper_Mapper_WhishListItem extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
 {
+    /**
+     * Name to address custom mappers via config.xml
+     */
+    const MAPPER_IDENTIFIER = 'whishlist_item';
 }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Config/Mapper.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Config/Mapper.php
@@ -44,7 +44,7 @@ class Divante_VueStorefrontBridge_Model_Config_Mapper
                     continue;
                 }
 
-                $initialDto = $model->filterDto($initialDto);
+                $initialDto = $model->filterDto($initialDto, false);
             }
         }
 

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Config/Mapper.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/Model/Config/Mapper.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Class Divante_VueStorefrontBridge_Model_Config_Mapper
+ */
+class Divante_VueStorefrontBridge_Model_Config_Mapper
+{
+    /**
+     * Mapper xml config path
+     */
+    const MAPPER_CONFIG_ROOT_NODE  = 'global/vsf_bridge/mapper/types';
+
+    /**
+     * @var array
+     */
+    protected $config = array();
+
+    /**
+     * @return array
+     */
+    public function __construct()
+    {
+        $mappingConfigTypes = Mage::getConfig()->getNode(self::MAPPER_CONFIG_ROOT_NODE)->asArray();
+        foreach ($mappingConfigTypes as $mappingIdentifier => $mapper) {
+            $this->config[$mappingIdentifier] =  $mapper['mapper'];
+        }
+
+        return $this->config;
+    }
+
+    /**
+     * @param string $type
+     * @param array $initialDto
+     * @return array
+     */
+    public function applyExtendedMapping($type, &$initialDto)
+    {
+        if ($this->config[$type] && !empty($this->config[$type])) {
+            foreach ($this->config[$type] as $name => $className) {
+                $model = Mage::getModel($className);
+                if (!$model || !$model instanceof Divante_VueStorefrontBridge_Helper_Mapper_Abstract) {
+                    $error = 'Class "%s" is not an instance on "Divante_VueStorefrontBridge_Helper_Mapper_Abstract".';
+                    Mage::log(sprintf($error, $className), 'system.log', true);
+                    continue;
+                }
+
+                $initialDto = $model->filterDto($initialDto);
+            }
+        }
+
+        return $initialDto;
+    }
+}

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AbstractController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AbstractController.php
@@ -224,27 +224,7 @@ class Divante_VueStorefrontBridge_AbstractController extends Mage_Core_Controlle
 
         return $paramsDTO;
     }
-    /**
-     * Filters parameters map removing blacklisted
-     *
-     * @param array      $dtoToFilter
-     * @param array|null $blackList
-     *
-     * @return mixed
-     */
-    protected function _filterDTO(array $dtoToFilter, array $blackList = null)
-    {
-        foreach ($dtoToFilter as $key => $val) {
-            if ($blackList && in_array($key, $blackList)) {
-                unset ($dtoToFilter[$key]);
-            } else {
-                if (strstr($key, 'is_') || strstr($key, 'has_')) {
-                    $dtoToFilter[$key] = boolval($val);
-                }
-            }
-        }
-        return $dtoToFilter;
-    }
+
     /**
      * Sends back code and result of performed operation
      *
@@ -258,8 +238,7 @@ class Divante_VueStorefrontBridge_AbstractController extends Mage_Core_Controlle
                 [
                     'code'   => $code,
                     'result' => $result,
-                ],
-                JSON_NUMERIC_CHECK
+                ]
             )
         )
             ->setHttpResponseCode($code)

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AttributesController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AttributesController.php
@@ -50,7 +50,8 @@ class Divante_VueStorefrontBridge_AttributesController extends Divante_VueStoref
                 /** @var Mage_Catalog_Model_Resource_Eav_Attribute $productAttr */
                 $attribute = Mage::getSingleton('eav/config')
                     ->getAttribute(Mage_Catalog_Model_Product::ENTITY, $productAttr->getAttributeCode());
-                $options   = [];
+
+                $options = [];
                 if ($attribute->usesSource()) {
                     $options = $attribute->getSource()->getAllOptions(false);
                 }
@@ -61,11 +62,11 @@ class Divante_VueStorefrontBridge_AttributesController extends Divante_VueStoref
                     continue;
                 } // exception - this attribute has string typed values; this is not acceptable by VS
 
-                $productAttrDTO['id']            = intval($productAttr->getAttributeId());
+                $productAttrDTO['id']            = $productAttr->getAttributeId();
                 $productAttrDTO['options']       = $options;
                 $productAttrDTO['default_value'] = (int)$productAttrDTO['default_value'];
-                $productAttrDTO                  = $this->_filterDTO($productAttrDTO);
-                $attrList[]                      = $productAttrDTO;
+
+                $attrList[] = Mage::helper('vsbridge_mapper/productAttribute')->filterDto($productAttrDTO);
             }
             $this->_result(200, $attrList);
         }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/CartController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/CartController.php
@@ -112,7 +112,10 @@ class Divante_VueStorefrontBridge_CartController extends Divante_VueStorefrontBr
             $items = [];
 
             foreach ($quoteObj->getAllVisibleItems() as $item) {
-                $items[] = $this->cartModel->getItemAsArray($item);
+                $quoteItemDTO = $this->cartModel->getItemAsArray($item);
+                $quoteItemDTO = Mage::helper('vsbridge_mapper/quoteItem')->filterDto($quoteItemDTO);
+
+                $items[] = $quoteItemDTO;
             }
 
             return $this->_result(200, $items);

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/CategoriesController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/CategoriesController.php
@@ -37,23 +37,6 @@ class Divante_VueStorefrontBridge_CategoriesController extends Divante_VueStoref
     }
 
     /**
-     * Prepares category entity data
-     *
-     * @param Mage_Catalog_Model_Category $category
-     *
-     * @return mixed
-     */
-    protected function _prepareDTO(Mage_Catalog_Model_Category $category)
-    {
-        $categoryDTO       = $category->getData();
-        $categoryDTO['id'] = intval($categoryDTO['entity_id']);
-        unset($categoryDTO['entity_id']);
-        unset($categoryDTO['path']);
-
-        return $categoryDTO;
-    }
-
-    /**
      * Processes category data
      *
      * @param Mage_Catalog_Model_Category $category
@@ -63,16 +46,16 @@ class Divante_VueStorefrontBridge_CategoriesController extends Divante_VueStoref
      */
     protected function _processCategory(Mage_Catalog_Model_Category $category, $level = 0)
     {
-        $childCats               = $category->getChildrenCategories();
-        $catDTO                  = $this->_prepareDTO($category);
+        $catDTO                  = $category->getData();
+        $catDTO['id']            = $catDTO['entity_id'];
         $catDTO['children_data'] = [];
-        foreach ($childCats as $childCategory) {
+
+        foreach ($category->getChildrenCategories() as $childCategory) {
             $catDTO['children_data'][] = $this->_processCategory($childCategory, $level + 1);
         }
+
         // $catDTO['level'] = $level;
         $catDTO['children_count'] = count($catDTO['children_data']);
-        $catDTO                   = $this->_filterDTO($catDTO);
-
-        return $catDTO;
+        return Mage::helper('vsbridge_mapper/category')->filterDto($catDTO);
     }
 }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/ProductsController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/ProductsController.php
@@ -17,26 +17,6 @@ class Divante_VueStorefrontBridge_ProductsController extends Divante_VueStorefro
     {
         if ($this->_authorizeAdminUser($this->getRequest())) {
             $params = $this->_processParams($this->getRequest());
-            $confChildBlacklist = [
-                'entity_id',
-                'id',
-                'type_id',
-                'updated_at',
-                'created_at',
-                'stock_item',
-                'short_description',
-                'page_layout',
-                'news_from_date',
-                'news_to_date',
-                'meta_description',
-                'meta_keyword',
-                'meta_title',
-                'description',
-                'attribute_set_id',
-                'entity_type_id',
-                'has_options',
-                'required_options',
-            ];
 
             $result = [];
             $productCollection = Mage::getModel('catalog/product')
@@ -91,7 +71,7 @@ class Divante_VueStorefrontBridge_ProductsController extends Divante_VueStorefro
                             $productDTO[$productAttribute['attribute_code'] . '_options'] = $availableOptions;
                         }
 
-                        $childDTO = $this->_filterDTO($childDTO, $confChildBlacklist);
+                        $childDTO = Mage::helper('vsbridge_mapper/productChild')->filterDto($childDTO);
                         $productDTO['configurable_children'][] = $childDTO;
                     }
                 }
@@ -101,14 +81,17 @@ class Divante_VueStorefrontBridge_ProductsController extends Divante_VueStorefro
                 $productDTO['category_ids'] = [];
                 foreach ($cats as $category_id) {
                     $cat = Mage::getModel('catalog/category')->load($category_id);
-                    $productDTO['category'][] = [
+                    $categoryDTO = [
                         'category_id' => $cat->getId(),
                         'name' => $cat->getName()
                     ];
+                    $categoryDTO = Mage::helper('vsbridge_mapper/category')->filterDto($categoryDTO);
+
+                    $productDTO['category'][] = $categoryDTO;
                     $productDTO['category_ids'][] = $category_id;
                 }
 
-                $productDTO = $this->_filterDTO($productDTO);
+                $productDTO = Mage::helper('vsbridge_mapper/product')->filterDto($productDTO);
                 $result[] = $productDTO;
             }
 

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/StockController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/StockController.php
@@ -34,9 +34,10 @@ class Divante_VueStorefrontBridge_StockController extends Divante_VueStorefrontB
             $product_id = Mage::getModel('catalog/product')->getIdBySku($sku);
             $product = Mage::getModel('catalog/product')->load($product_id);
             $stock = $product->getStockItem();
+
             $stockDTO = $stock->getData();
-            $stockDTO['is_in_stock'] = boolval($stockDTO['is_in_stock']);
             $stockDTO['notify_stock_qty'] = $stock->getNotifyStockQty();
+            $stockDTO = Mage::helper('vsbridge_mapper/stock')->filterDto($stockDTO);
 
             return $this->_result(200, $stockDTO);
         } catch (Exception $err) {

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/TaxrulesController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/TaxrulesController.php
@@ -32,23 +32,24 @@ class Divante_VueStorefrontBridge_TaxrulesController extends Divante_VueStorefro
             $taxRules = array();
             if ($collection->getSize()) {
                 foreach ($collection as $rule) {
-                    $taxRuleDTO       = $rule->getData();
-                    $taxRuleDTO['id'] = intval($taxRuleDTO['tax_calculation_rule_id']);
-                    unset($taxRuleDTO['tax_calculation_rule_id']);
+                    $taxRuleDTO = $rule->getData();
+
+                    $taxRuleDTO['id'] = $taxRuleDTO['tax_calculation_rule_id'];
                     $taxRuleDTO['tax_rates_ids'] = $taxRuleDTO['tax_rates'];
-                    unset($taxRuleDTO['tax_rates']);
                     $taxRuleDTO['product_tax_class_ids'] = $taxRuleDTO['product_tax_classes'];
-                    unset($taxRuleDTO['product_tax_classes']);
                     $taxRuleDTO['customer_tax_class_ids'] = $taxRuleDTO['customer_tax_classes'];
-                    unset($taxRuleDTO['customer_tax_classes']);
                     $taxRuleDTO['rates'] = [];
+
                     foreach ($taxRuleDTO['tax_rates_ids'] as $rateId) {
                         $rate->load($rateId);
                         $rateDTO       = $rate->getData();
-                        $rateDTO['id'] = intval($rateDTO['tax_calculation_rate_id']);
-                        unset($rateDTO['tax_calculation_rate_id']);
+                        $rateDTO['id'] = $rateDTO['tax_calculation_rate_id'];
+                        $rateDTO = Mage::helper('vsbridge_mapper/taxruleRate')->filterDto($rateDTO);
+
                         $taxRuleDTO['rates'][] = $rateDTO;
                     }
+
+                    $taxRuleDTO = Mage::helper('vsbridge_mapper/taxrule')->filterDto($taxRuleDTO);
                     $taxRules[] = $taxRuleDTO;
                 }
             }

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/WishlistController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/WishlistController.php
@@ -226,7 +226,7 @@ class Divante_VueStorefrontBridge_WishlistController extends Divante_VueStorefro
             'wishlist_item_id' => $item->getId(),
         ];
 
-        return $wishListDTO;
+        return Mage::helper('vsbridge_mapper/whishListItem')->filterDto($wishListDTO);
     }
 
     /**

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
@@ -26,6 +26,9 @@
             <vsbridge>
                 <class>Divante_VueStorefrontBridge_Helper</class>
             </vsbridge>
+            <vsbridge_mapper>
+                <class>Divante_VueStorefrontBridge_Helper_Mapper</class>
+            </vsbridge_mapper>
         </helpers>
     </global>
     <default>

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
@@ -30,6 +30,18 @@
                 <class>Divante_VueStorefrontBridge_Helper_Mapper</class>
             </vsbridge_mapper>
         </helpers>
+        <vsf_bridge>
+            <mapper>
+                <types>
+                    <!--address>
+                        <mapper>
+                            <add_custom_attribute_mapping>Divante_VueStorefrontIndexer_Helper_Mapper_CustomClass</add_custom_attribute_mapping>
+                            <filter_another_attribute>Divante_VueStorefrontIndexer_Helper_Mapper_SecondCustomClass</filter_another_attribute>
+                        </mapper>
+                    </address-->
+                </type>
+            </mapper>
+        </vsf_bridge>
     </global>
     <default>
         <vsbridge>

--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/etc/config.xml
@@ -35,11 +35,11 @@
                 <types>
                     <!--address>
                         <mapper>
-                            <add_custom_attribute_mapping>Divante_VueStorefrontIndexer_Helper_Mapper_CustomClass</add_custom_attribute_mapping>
-                            <filter_another_attribute>Divante_VueStorefrontIndexer_Helper_Mapper_SecondCustomClass</filter_another_attribute>
+                            <add_custom_attribute_mapping>Divante_VueStorefrontBridge_Helper_Mapper_CustomClass</add_custom_attribute_mapping>
+                            <filter_another_attribute>Divante_VueStorefrontBridge_Helper_Mapper_SecondCustomClass</filter_another_attribute>
                         </mapper>
                     </address-->
-                </type>
+                </types>
             </mapper>
         </vsf_bridge>
     </global>


### PR DESCRIPTION
This is a further extension of #25.

It's about the automatic the JSON mapping using `JSON_NUMERIC_CHECK` which causes some type errors, for example for leading zeros in numeric strings (which should stay strings) – like in some german postcodes or telephone numbers with a leading zero.

I added a way to extend the mappings of @mtarld using the `config.xml` like in `DivanteLtd/magento1-vsbridge-indexer`. So now you can add a custom mapper for your type by adding a module with the following config xml node:
```xml
<?xml version="1.0"?>
<config>
    <global>
        <vsf_bridge>
            <mapper>
                <types>
                    <address>
                        <mapper>
                            <add_custom_attribute_mapping>Divante_VueStorefrontBridge_Helper_Mapper_CustomClass</add_custom_attribute_mapping>
                            <filter_another_attribute>Divante_VueStorefrontBridge_Helper_Mapper_SecondCustomClass</filter_another_attribute>
                        </mapper>
                    </address>
                </type>
            </mapper>
        </vsf_bridge>
    </global>
</config>
```

The classes for the mapper extensions declared  above must extend the `Divante_VueStorefrontBridge_Helper_Mapper_Abstract` class and should contain your custom mappings and options for your custom attributes.

For example: the following code in combination with the configs above will filter out the attributes `firstname` and `lastname` from the addresses response object.
```php
<?php

class Divante_VueStorefrontBridge_Helper_Mapper_CustomClass extends Divante_VueStorefrontBridge_Helper_Mapper_Abstract
{
    /**
     * Get Dto attribute blacklist
     *
     * @return array
     */
    protected function getBlacklist()
    {
        return ['firstname', 'lastname'];
    }
}
```
This way the mapping is more flexible and can be extended without overwriting classes.