### PR TITLE
Additional check on the json encode

### DIFF
--- a/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AbstractController.php
+++ b/magento1-module/app/code/local/Divante/VueStorefrontBridge/controllers/AbstractController.php
@@ -253,15 +253,20 @@ class Divante_VueStorefrontBridge_AbstractController extends Mage_Core_Controlle
      */
     protected function _result($code, $result)
     {
-        $this->getResponse()->setBody(
-            json_encode(
-                [
-                    'code'   => $code,
-                    'result' => $result,
-                ],
-                JSON_NUMERIC_CHECK
-            )
-        )
+        $bodyRequest = json_encode(
+            [
+                'code'   => $code,
+                'result' => $result,
+            ],
+            JSON_NUMERIC_CHECK
+        );
+        
+        if ($bodyRequest === false) {
+            // If the json encode with numeric check option fail, I encode without that option
+            $bodyRequest = json_encode([ 'code' => $code, 'result' => $result ]);
+        }
+        
+        $this->getResponse()->setBody($bodyRequest)
             ->setHttpResponseCode($code)
             ->setHeader('Content-Type', 'application/json')
             ->setHeader('Cache-Control', 'no-cache');


### PR DESCRIPTION
In some cases, the option JSON_NUMERIC_CHECK of the json_encode doesn't allow to encode the data correctly.
This commit adds a check: if the JSON encode with numeric check fail, it encodes without that option.